### PR TITLE
attempt to fix travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: false
 language: perl
 perl:
-   - 'blead'
-   - '5.22'
-   - '5.20'
-install:
-   - cpanm --quiet --notest --skip-satisfied Dist::Zilla
-   - "dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest"
-   - "dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose"
-script:
-   - dzil smoke --release --author
+  - "5.10"
+  - "5.14"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "blead"
+sudo: false             # faster builds as long as you don't need sudo access
+before_install:
+  - eval $(curl https://travis-perl.github.io/init) --auto

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,9 @@ license = Perl_5
 copyright_holder = Zoffix Znet <cpan@zoffix.com>
 
 [@Author::ZOFFIX]
+[MetaJSON]
 [Prereqs]
 Mojolicious = 6.36
 IO::Socket::SSL = 1.94
+
 


### PR DESCRIPTION
User travis-perl helpers
It seems that travis-perl helpers require META.json for author deps to
be installed correctly, so add that to dist.ini